### PR TITLE
metricToFOM uses uniqueID and metric name as column names, to handle duplicate metric names

### DIFF
--- a/contrib/05_metricToFOM.ipynb
+++ b/contrib/05_metricToFOM.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {
     "scrolled": true
    },
@@ -310,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,7 +399,11 @@
     "        tWrite['runNames'] = runNames\n",
     "        for iMetric in range(len(metrics)):\n",
     "            thisFom = FOMs[iMetric]\n",
-    "            colName = list(metrics)[iMetric][-1] ### keys are a dict_keys object\n",
+    "            \n",
+    "            ### 2020-08-06 hack to handle repeated metric names\n",
+    "            indexStr = ('%i' % (iMetric)).zfill(2)\n",
+    "            metricName = list(metrics)[iMetric][-1]\n",
+    "            colName = '%s_%s' % (indexStr, metricName)\n",
     "            thisCol = Column(name=colName, data=thisFom)\n",
     "            tWrite.add_column(thisCol)\n",
     "            \n",
@@ -497,7 +501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -505,11 +509,11 @@
      "output_type": "stream",
      "text": [
       "Written FoM sums to path ./testFoMs.csv. Contents:\n",
-      "        runNames         LSPMmetric TransienPM confusionmetric  FomSum \n",
-      "------------------------ ---------- ---------- --------------- --------\n",
-      "      spiders_v1.4_10yrs    121.370    765.479         743.514 1630.364\n",
-      "       agnddf_v1.4_10yrs    147.211    777.393         500.710 1425.313\n",
-      "twi_filters_5_v1.4_10yrs    136.950    770.357         743.557 1650.864\n"
+      "        runNames         00_LSPMmetric 01_TransienPM 02_confusionmetric  FomSum \n",
+      "------------------------ ------------- ------------- ------------------ --------\n",
+      "      spiders_v1.4_10yrs       121.370       765.479            743.514 1630.364\n",
+      "       agnddf_v1.4_10yrs       147.211       777.393            500.710 1425.313\n",
+      "twi_filters_5_v1.4_10yrs       136.950       770.357            743.557 1650.864\n"
      ]
     },
     {
@@ -519,7 +523,7 @@
        "<Figure size 800x3000 with 1 Axes>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -529,6 +533,13 @@
     "# showing the first few lines of the table to terminal. \n",
     "FOM(bundleDicts, tablePath=pathTableOut, Verbose=True, byfamily=byFamily, cmap=cmap)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/contrib/05_metricToFOM.ipynb
+++ b/contrib/05_metricToFOM.ipynb
@@ -280,17 +280,20 @@
     "if your_username == '': # do NOT put your username here, put it in the cell at the top of the notebook.\n",
     "    raise Exception('Please provide your username!  See the top of the notebook.')\n",
     "    \n",
-    "outDir = '/home/idies/workspace/Storage/{}/persistent/{}'.format(your_username, searchTail)\n",
+    "### 2020-08-06 updated to search for \"result\" and \"data\" paths separately\n",
+    "# outDir = '/home/idies/workspace/Storage/{}/persistent/{}'.format(your_username, searchTail)\n",
     "\n",
+    "resultDbPath = '/home/idies/workspace/Storage/{}/persistent/{}'.format(your_username, searchTail)\n",
+    "metricDataPath =  '/home/idies/workspace/Storage/{}/persistent/{}'.format(your_username, searchTail)\n",
     "\n",
-    "resultDbs = getResultsDbs(outDir)\n",
+    "resultDbs = getResultsDbs(resultDbPath)\n",
     "\n",
     "# the following line will be useful if you did not run MAF on all 75 opsims\n",
     "#Here we upload the results from the MAFoutput of interest\n",
     "runNames = list(resultDbs.keys())\n",
     "bundleDicts = {}\n",
     "for runName in runNames:\n",
-    "       bundleDicts[runName] = bundleDictFromDisk(resultDbs[runName], runName, outDir)\n"
+    "       bundleDicts[runName] = bundleDictFromDisk(resultDbs[runName], runName, metricDataPath)\n"
    ]
   },
   {
@@ -539,6 +542,21 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/idies/workspace/Storage/wiclarks/persistent/forks/LSST_OpSim/contrib\n"
+     ]
+    }
+   ],
    "source": []
   },
   {


### PR DESCRIPTION
In **def FOM()**, the column names in the astropy table are concatenated from the row number and the metric name in the **dict_keys()** object. This should gracefully cope with duplicate metric names with different IDs. Now the table column names look like this:

`runNames         00_LSPMmetric 01_TransienPM 02_confusionmetric  FomSum `
